### PR TITLE
Using api key instead of app group

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,10 @@ target/
 
 #Ipython Notebook
 .ipynb_checkpoints
+
+# Virtualenv
+.pyenv/
+.venv/
+.py2/
+.py3/
+

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ $ python setup.py install
 ```python
 from appboy.client import AppboyClient
 
-client = AppboyClient(app_group_id='YOUR_GROUP_ID')
+client = AppboyClient(api_key='YOUR_API_KEY')
 
 r = client.user_track(
     attributes=[{
@@ -53,6 +53,6 @@ For more examples, check `examples.py`.
 
 ### How to test
 
-To run the unit tests, make sure you have the [nose](http://nose.readthedocs.org/) module instaled and run the following from the repository root directory:
+To run the unit tests, make sure you have the [tox](https://tox.readthedocs.io/en/latest/) module installed and run the following from the repository root directory:
 
-`$ nosetests`
+`$ tox`

--- a/appboy/client.py
+++ b/appboy/client.py
@@ -35,8 +35,8 @@ class AppboyClient(object):
 
     REQUEST_POST = 'post'
 
-    def __init__(self, app_group_id):
-        self.app_group_id = app_group_id
+    def __init__(self, api_key):
+        self.api_key = api_key
         self.requests = requests
         self.request_url = ''
         self.headers = {}
@@ -88,7 +88,7 @@ class AppboyClient(object):
             'Content-Type': 'application/json',
         }
 
-        payload['app_group_id'] = self.app_group_id
+        payload['api_key'] = self.api_key
 
         response = {}
 

--- a/examples.py
+++ b/examples.py
@@ -1,6 +1,6 @@
 from appboy.client import AppboyClient
 
-client = AppboyClient(app_group_id='YOUR_GROUP_ID')
+client = AppboyClient(api_key='YOUR_API_KEY')
 
 # For create - update users
 r = client.user_track(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -32,10 +32,10 @@ class DummyRequestException(object):
 
 class TestAppboyClient(unittest.TestCase):
     def setUp(self):
-        self.client = AppboyClient(app_group_id='APP_GROUP_ID')
+        self.client = AppboyClient(api_key='API_KEY')
 
     def test_init(self):
-        self.assertEqual(self.client.app_group_id, 'APP_GROUP_ID')
+        self.assertEqual(self.client.api_key, 'API_KEY')
         self.assertIsNotNone(self.client.requests)
         self.assertEqual(self.client.request_url, '')
         self.assertEqual(self.client.headers, {})
@@ -59,7 +59,7 @@ class TestAppboyClient(unittest.TestCase):
 
         response = self.client.user_track(attributes=attributes, events=events, purchases=purchases)
 
-        self.assertEqual('https://api.appboy.com/users/track', self.client.request_url)
+        self.assertEqual(self.client.API_URL + '/users/track', self.client.request_url)
         self.assertEqual(self.client.headers['Content-Type'], 'application/json')
 
         self.assertEqual(response['status_code'], 200)
@@ -86,7 +86,7 @@ class TestAppboyClient(unittest.TestCase):
 
         response = self.client.user_track(attributes=attributes, events=events, purchases=purchases)
 
-        self.assertEqual('https://api.appboy.com/users/track', self.client.request_url)
+        self.assertEqual(self.client.API_URL + '/users/track', self.client.request_url)
         self.assertEqual(self.client.headers['Content-Type'], 'application/json')
 
         self.assertEqual(response['status_code'], 0)


### PR DESCRIPTION
Forked hellofresh's repo, made similar PR on their repo as well: https://github.com/hellofresh/appboy-python-client/pull/6

Updating according to latest braze documentation.
https://www.braze.com/docs/developer_guide/rest_api/user_data/#user-track-request