### PR TITLE
Trickle up fatal braze errors as exceptions

### DIFF
--- a/braze/client.py
+++ b/braze/client.py
@@ -25,10 +25,21 @@ class BrazeRateLimitError(Exception):
 
 
 class BrazeClientError(Exception):
+    """
+    Represents any Braze Fatal Error.
+
+    https://www.braze.com/docs/developer_guide/rest_api/user_data/#user-track-responses
+    """
+
     pass
 
 
 class BrazeInternalServerError(BrazeClientError):
+    """
+    Used for Braze API responses where response code is of type 5XX suggesting
+    Braze side server errors.
+    """
+
     pass
 
 

--- a/braze/client.py
+++ b/braze/client.py
@@ -1,7 +1,6 @@
 import time
 
 import requests
-from requests.exceptions import RequestException
 from tenacity import retry
 from tenacity import stop_after_attempt
 from tenacity import wait_random_exponential

--- a/braze/client.py
+++ b/braze/client.py
@@ -150,19 +150,13 @@ class BrazeClient(object):
         response["status_code"] = r.status_code
 
         message = response["message"]
-        if message == "success" or message == "queued":
-            if not response["errors"]:
-                response["success"] = True
-            else:
-                # Non-Fatal errors
-                pass
+        response["success"] = (
+            message in ("success", "queued") and not response["errors"]
+        )
 
         if message != "success":
             # message contains the fatal error message from Braze
             raise BrazeClientError(message, response["errors"])
-
-        if "success" not in response:
-            response["success"] = False
 
         if "status_code" not in response:
             response["status_code"] = 0

--- a/tests/braze/test_client.py
+++ b/tests/braze/test_client.py
@@ -1,6 +1,7 @@
 import time
 
-from braze.client import _wait_random_exp_or_rate_limit
+from braze.client import _wait_random_exp_or_rate_limit, BrazeClientError, \
+    BrazeInternalServerError
 from braze.client import BrazeClient
 from braze.client import BrazeRateLimitError
 from braze.client import MAX_RETRIES
@@ -93,22 +94,24 @@ class TestBrazeClient(object):
     def test_user_track_request_exception(
         self, braze_client, mocker, attributes, events, purchases
     ):
-        error_msg = "RequestException Error Message"
         mocker.patch.object(
             BrazeClient,
             "_post_request_with_retries",
-            side_effect=RequestException(error_msg),
+            side_effect=RequestException,
         )
 
-        response = braze_client.user_track(
-            attributes=attributes, events=events, purchases=purchases
-        )
+        with pytest.raises(RequestException):
+            braze_client.user_track(
+                attributes=attributes, events=events, purchases=purchases
+            )
+
         assert braze_client.api_url + "/users/track" == braze_client.request_url
-        assert response["status_code"] == 0
-        assert error_msg in response["errors"]
 
     @pytest.mark.parametrize(
-        "status_code, retry_attempts", [(500, MAX_RETRIES), (401, 1)]
+        "status_code, retry_attempts, error",
+        [
+            (500, MAX_RETRIES, BrazeInternalServerError),
+            (401, 1, BrazeClientError)]
     )
     def test_retries_for_errors(
         self,
@@ -119,6 +122,7 @@ class TestBrazeClient(object):
         attributes,
         events,
         purchases,
+        error,
     ):
         headers = {"Content-Type": "application/json"}
         error_msg = "Internal Server Error"
@@ -127,13 +131,13 @@ class TestBrazeClient(object):
             ANY, json=mock_json, status_code=status_code, headers=headers
         )
 
-        response = braze_client.user_track(
-            attributes=attributes, events=events, purchases=purchases
-        )
+        with pytest.raises(error):
+            braze_client.user_track(
+                attributes=attributes, events=events, purchases=purchases
+            )
 
         stats = braze_client._post_request_with_retries.retry.statistics
         assert stats["attempt_number"] == retry_attempts
-        assert response["success"] is False
 
     @freeze_time()
     @pytest.mark.parametrize(
@@ -159,14 +163,13 @@ class TestBrazeClient(object):
         mock_json = {"message": error_msg, "errors": error_msg}
         requests_mock.post(ANY, json=mock_json, status_code=429, headers=headers)
 
-        response = braze_client.user_track(
-            attributes=attributes, events=events, purchases=purchases
-        )
+        with pytest.raises(BrazeRateLimitError):
+            braze_client.user_track(
+                attributes=attributes, events=events, purchases=purchases
+            )
 
         stats = braze_client._post_request_with_retries.retry.statistics
         assert stats["attempt_number"] == expected_attempts
-        assert response["success"] is False
-        assert "BrazeRateLimitError" in response["errors"]
 
         # Ensure the correct wait time is used when rate limited
         for i in range(expected_attempts - 1):

--- a/tests/braze/test_client.py
+++ b/tests/braze/test_client.py
@@ -1,8 +1,9 @@
 import time
 
-from braze.client import _wait_random_exp_or_rate_limit, BrazeClientError, \
-    BrazeInternalServerError
+from braze.client import _wait_random_exp_or_rate_limit
 from braze.client import BrazeClient
+from braze.client import BrazeClientError
+from braze.client import BrazeInternalServerError
 from braze.client import BrazeRateLimitError
 from braze.client import MAX_RETRIES
 from braze.client import MAX_WAIT_SECONDS
@@ -95,9 +96,7 @@ class TestBrazeClient(object):
         self, braze_client, mocker, attributes, events, purchases
     ):
         mocker.patch.object(
-            BrazeClient,
-            "_post_request_with_retries",
-            side_effect=RequestException,
+            BrazeClient, "_post_request_with_retries", side_effect=RequestException
         )
 
         with pytest.raises(RequestException):
@@ -109,9 +108,7 @@ class TestBrazeClient(object):
 
     @pytest.mark.parametrize(
         "status_code, retry_attempts, error",
-        [
-            (500, MAX_RETRIES, BrazeInternalServerError),
-            (401, 1, BrazeClientError)]
+        [(500, MAX_RETRIES, BrazeInternalServerError), (401, 1, BrazeClientError)],
     )
     def test_retries_for_errors(
         self,


### PR DESCRIPTION
As discussed offline between @AA33 and @pramttl, trickle up exceptions. The exceptions are trickled up post retry logic.

This allows the consumer of the client to add custom behavior based on the exception.