### PR TITLE
Bump version for release (v2.2.0)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages
 from setuptools import setup
 
 NAME = "braze-client"
-VERSION = "2.1.0"
+VERSION = "2.2.0"
 
 REQUIRES = ["requests >=2.21.0, <3.0.0", "tenacity >=5.0.0, <6.0.0"]
 


### PR DESCRIPTION
Bumps the version number v2.2.0 (for changes already on master but not yet having a release)

See #5 for more details on changes that will be 🚢 ed in this release.