### PR TITLE
Allow external ids and email at once

### DIFF
--- a/braze/client.py
+++ b/braze/client.py
@@ -151,9 +151,9 @@ class BrazeClient(object):
 
     def user_export(self, external_ids=None, email=None, fields_to_export=None):
         """
-        Export user profiles from braze. One of ``external_ids`` or ``email`` must be
-        provided. Braze allows exporting multiple user profiles through ``external_ids``
-        but only one with the ``email`` argument.
+        Export user profiles from braze. One or both of ``external_ids`` or ``email``
+        must be provided. Braze allows exporting multiple user profiles through
+        ``external_ids`` but only one with the ``email`` argument.
         ref: https://www.braze.com/docs/developer_guide/rest_api/export/
 
         :param list[str] external_ids:
@@ -168,9 +168,6 @@ class BrazeClient(object):
         """
         if external_ids is email is None:
             raise ValueError("At least one of external_ids or email must be specified")
-
-        if external_ids is not None and email is not None:
-            raise ValueError("Both external_ids and email are specified")
 
         self.request_url = self.api_url + USER_EXPORT_ENDPOINT
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages
 from setuptools import setup
 
 NAME = "braze-client"
-VERSION = "2.2.4"
+VERSION = "2.2.5"
 
 REQUIRES = ["requests >=2.21.0, <3.0.0", "tenacity >=5.0.0, <6.0.0"]
 


### PR DESCRIPTION
Braze allows this and responds with the unique set of all users covered by external_ids + email. 
We also have a use case for it. 
In coupon email we will use this to figure out if a new profile needs to be created for a `grx_profile_id` and `email` pair. Instead of two calls this can be done in one call if braze client supports it.