### PR TITLE
Add support for auth using HTTP Authorization request header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+.python-version
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ target/
 .py2/
 .py3/
 
+
+# PyCharm
+.idea

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 A Python client for the Braze REST API
 
 [![Build Status](https://travis-ci.com/dtatarkin/braze-client.svg?branch=master)](https://travis-ci.com/dtatarkin/braze-client)
-[![Coverage](https://codecov.io/gh/GoodRx/dtatarkin/branch/master/graph/badge.svg)](https://codecov.io/gh/dtatarkin/braze-client)
+[![Coverage](https://codecov.io/gh/dtatarkin/braze-client/branch/master/graph/badge.svg)](https://codecov.io/gh/dtatarkin/braze-client)
 
 ### How to install
 
@@ -45,6 +45,7 @@ For more examples, check `examples.py`.
 
 ### How to test
 
-To run the unit tests, make sure you have the [tox](https://tox.readthedocs.io/en/latest/) module installed and run the following from the repository root directory:
+To run the unit tests, make sure you have the [tox](https://tox.readthedocs.io/en/latest/) module installed 
+and run the following from the repository root directory:
 
 `$ tox`

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # braze-client
 A Python client for the Braze REST API
 
-[![Build Status](https://travis-ci.com/GoodRx/braze-client.svg?branch=master)](https://travis-ci.com/GoodRx/braze-client)
-[![Coverage](https://codecov.io/gh/GoodRx/braze-client/branch/master/graph/badge.svg)](https://codecov.io/gh/GoodRx/braze-client)
+[![Build Status](https://travis-ci.com/dtatarkin/braze-client.svg?branch=master)](https://travis-ci.com/dtatarkin/braze-client)
+[![Coverage](https://codecov.io/gh/GoodRx/dtatarkin/branch/master/graph/badge.svg)](https://codecov.io/gh/dtatarkin/braze-client)
 
 ### How to install
 
-Make sure you have Python 2.7.11+ installed and run:
+Make sure you have Python 2.7+ or 3.6+ installed and run:
 
 ```
-$ git clone https://github.com/GoodRx/braze-client
+$ git clone https://github.com/dtatarkin/braze-client
 $ cd braze-client
 $ python setup.py install
 ```

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ $ python setup.py install
 
 ```python
 from braze.client import BrazeClient
-client = BrazeClient(api_key='YOUR_API_KEY')
+client = BrazeClient(api_key='YOUR_API_KEY', use_auth_header=True)
 
 r = client.user_track(
     attributes=[{

--- a/braze/client.py
+++ b/braze/client.py
@@ -100,6 +100,7 @@ class BrazeClient(object):
         self.api_url = api_url or DEFAULT_API_URL
         self.use_auth_header = use_auth_header
         self.session = requests.Session()
+        self.session.headers.update({"User-Agent": "braze-client python"})
         self.request_url = ""
 
     def user_track(self, attributes=None, events=None, purchases=None):

--- a/braze/client.py
+++ b/braze/client.py
@@ -1,9 +1,8 @@
-import time
-
 import requests
 from tenacity import retry
 from tenacity import stop_after_attempt
 from tenacity import wait_random_exponential
+import time
 
 DEFAULT_API_URL = "https://rest.iad-02.braze.com"
 USER_TRACK_ENDPOINT = "/users/track"
@@ -73,7 +72,7 @@ def _wait_random_exp_or_rate_limit():
 
 class BrazeClient(object):
     """
-    Client for Appboy public API. Support user_track.
+    Client for Braze public API. Support user_track.
     usage:
      from braze.client import BrazeClient
      client = BrazeClient(api_key='Place your API key here')
@@ -96,7 +95,7 @@ class BrazeClient(object):
         print r['errors']
     """
 
-    def __init__(self, api_key, api_url=None, use_auth_header=False):
+    def __init__(self, api_key, api_url=None, use_auth_header=True):
         self.api_key = api_key
         self.api_url = api_url or DEFAULT_API_URL
         self.use_auth_header = use_auth_header

--- a/setup.py
+++ b/setup.py
@@ -2,13 +2,13 @@ from setuptools import find_packages
 from setuptools import setup
 
 NAME = "braze-client"
-VERSION = "2.3.1"
+VERSION = "2.3.2"
 
 REQUIRES = ["requests >=2.21.0, <3.0.0", "tenacity >=5.0.0, <6.0.0"]
 
 EXTRAS = {"dev": ["tox"]}
 
-with open("README.md", "r", encoding="utf-8") as fh:
+with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(
@@ -28,6 +28,9 @@ setup(
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
     ],
-    python_requires=">=3.6",
+    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2., !=3.3.*, !=3.4.*, !=3.5.*",
 )

--- a/setup.py
+++ b/setup.py
@@ -2,17 +2,23 @@ from setuptools import find_packages
 from setuptools import setup
 
 NAME = "braze-client"
-VERSION = "2.2.6"
+VERSION = "2.3.1"
 
 REQUIRES = ["requests >=2.21.0, <3.0.0", "tenacity >=5.0.0, <6.0.0"]
 
 EXTRAS = {"dev": ["tox"]}
 
+with open("README.md", "r", encoding="utf-8") as fh:
+    long_description = fh.read()
+
 setup(
     name=NAME,
     version=VERSION,
     description="Braze Python Client",
-    author_email="azh@hellofresh.com",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://github.com/dtatarkin/braze-client",
+    author_email="mail@dtatarkin.ru",
     keywords=["Appboy", "Braze"],
     install_requires=REQUIRES,
     extras_require=EXTRAS,
@@ -20,6 +26,8 @@ setup(
     classifiers=[
         "Programming Language :: Python",
         "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
     ],
+    python_requires=">=3.6",
 )

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages
 from setuptools import setup
 
 NAME = "braze-client"
-VERSION = "2.3.2"
+VERSION = "2.3.3"
 
 REQUIRES = ["requests >=2.21.0, <3.0.0", "tenacity >=5.0.0, <6.0.0"]
 
@@ -32,5 +32,5 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
     ],
-    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2., !=3.3.*, !=3.4.*, !=3.5.*",
+    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*",
 )

--- a/tests/braze/test_client.py
+++ b/tests/braze/test_client.py
@@ -1,4 +1,11 @@
 from datetime import datetime
+from freezegun import freeze_time
+import pytest
+from pytest import approx
+from requests import RequestException
+from requests_mock import ANY
+from tenacity import Future
+from tenacity import RetryCallState
 import time
 from uuid import uuid4
 
@@ -10,13 +17,6 @@ from braze.client import BrazeRateLimitError
 from braze.client import CAMPAIGN_TRIGGER_SCHEDULE_CREATE
 from braze.client import MAX_RETRIES
 from braze.client import MAX_WAIT_SECONDS
-from freezegun import freeze_time
-import pytest
-from pytest import approx
-from requests import RequestException
-from requests_mock import ANY
-from tenacity import Future
-from tenacity import RetryCallState
 
 
 @pytest.fixture
@@ -174,7 +174,7 @@ class TestBrazeClient(object):
 
         # Ensure the correct wait time is used when rate limited
         for i in range(expected_attempts - 1):
-            assert approx(no_sleep.call_args_list[i][0], reset_delta_seconds)
+            assert no_sleep.call_args_list[i][0], approx(reset_delta_seconds)
 
     def test_user_export(self, braze_client, requests_mock):
         headers = {"Content-Type": "application/json"}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,8 @@
 from __future__ import absolute_import
 
-from braze.client import BrazeClient
 import pytest
+
+from braze.client import BrazeClient
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ import pytest
 
 @pytest.fixture
 def braze_client():
-    return BrazeClient(api_key="API_KEY")
+    return BrazeClient(api_key="API_KEY", use_auth_header=True)
 
 
 @pytest.fixture(autouse=True)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = style, py27, py37
+envlist = style, py27, py37, py38, py39, py310
 
 # Configs
 [pytest]
@@ -9,12 +9,12 @@ addopts = -p no:warnings
 [testenv]
 deps =
     codecov
-    freezegun == 0.3.11
+    freezegun
     mock
     pytest
     pytest-cov
     pytest-mock
-    requests-mock >= 1.3, < 2
+    requests-mock
 commands =
     pytest {posargs: --cov --cov-report=html}
 
@@ -22,7 +22,7 @@ commands =
 deps =
     coverage>=4.5.0
 commands =
-    coverage report --skip-covered -m --fail-under=100 --include="tests/*" --omit="tests/conftest.py"
+    coverage report --skip-covered -m --fail-under=100 --include="tests/*" --omit="tests/conftest.py" --omit="./venv/*"
 
 
 [testenv:py27]
@@ -35,21 +35,37 @@ basepython = python3.7
 deps = {[testenv]deps}
 commands = {[testenv]commands}
 
+[testenv:py38]
+basepython = python3.8
+deps = {[testenv]deps}
+commands = {[testenv]commands}
+
+[testenv:py39]
+basepython = python3.9
+deps = {[testenv]deps}
+commands = {[testenv]commands}
+
+[testenv:py310]
+basepython = python3.10
+deps = {[testenv]deps}
+commands = {[testenv]commands}
+
+
 [testenv:style]
 basepython = python3.7
 skip_install = true
 deps =
-    flake8 >= 3.0.4
+    flake8
     flake8-docstrings
     flake8-comprehensions
     flake8-bugbear
-    isort < 5.0.0
+    isort
     black
 
 commands =
     ; Check style violations
-    flake8 --ignore=D202,D205
+    flake8 --exclude venv,.tox --ignore=D202,D205
     ; Check that imports are sorted/formatted appropriately
-    isort --check-only --recursive
+    isort --extend-skip venv --extend-skip .tox --check-only .
     ; Check formatting
-    black --check .
+    black --extend-exclude venv --check .

--- a/tox.ini
+++ b/tox.ini
@@ -43,24 +43,13 @@ deps =
     flake8-docstrings
     flake8-comprehensions
     flake8-bugbear
-    {[testenv:format]deps}
+    isort < 5.0.0
+    black
+
 commands =
     ; Check style violations
-    flake8
+    flake8 --ignore=D202,D205
     ; Check that imports are sorted/formatted appropriately
     isort --check-only --recursive
     ; Check formatting
     black --check .
-
-
-; Run isort and black on a particular file or directory
-[testenv:format]
-basepython = python3.7
-skip_install = true
-deps =
-    isort >= 4.2.14
-    black
-commands =
-    ; Default to the entire codebase
-    isort --recursive {posargs: --apply}
-    black {posargs: .}


### PR DESCRIPTION
Prior to April 2020, API keys would be included as a part of the API request body or within the request URL as a parameter. Braze now has updated the way in which we read API keys. API keys are now set with the HTTP Authorization request header, making your API keys more secure.

While the old way of passing API keys continues to work, after a period of time this will be permenatly removed so we urge users to update API calls accordingly.
https://www.braze.com/docs/api/api_key/#how-can-i-use-it