### PR TITLE
Set user agent string

### DIFF
--- a/braze/client.py
+++ b/braze/client.py
@@ -100,6 +100,7 @@ class BrazeClient(object):
         self.api_key = api_key
         self.api_url = api_url or DEFAULT_API_URL
         self.session = requests.Session()
+        self.session.headers.update({'User-Agent': 'braze-client python'})
         self.request_url = ""
 
     def user_track(self, attributes=None, events=None, purchases=None):


### PR DESCRIPTION
I'm an engineer at Braze and we're trying to gather some usage data on the various community supported client libraries that exist. It would help us out to include this user agent string to identify the python client.

Thanks so much for building and maintaining this project! Let me know if you have any questions.